### PR TITLE
docs: add a table of contents and correct inaccurate README claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,8 @@ Three workflows run on push to main: `ci.yml` (tests),
 
 Super-linter excludes `dist/`, `docs/superpowers/`, and
 `.licenses/` directories. Markdown files must follow the config in
-`.github/linters/.markdown-lint.yml` (80 char line length, tables
-exempt).
+`.github/linters/.markdown-lint.yml` (120 char line length, tables
+exempt, dash bullets, underscore emphasis).
 
 `release.yml` triggers on SemVer tags (`v*.*.*`), updates rolling
 `vN` and `vN.N` tags, and creates a GitHub release.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,37 @@
 
 ![Docker Swarm Deployments](./.github/assets/deployment-action-overview.png)
 
+## 📑 Contents
+
+- [✨ Features](#-features)
+- [🚀 Getting Started](#-getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Simple Usage](#simple-usage)
+- [⚙️ Configuration](#️-configuration)
+  - [Inputs](#inputs)
+  - [Outputs](#outputs)
+- [📖 Reference](#-reference)
+  - [How Compose File Detection Works](#how-compose-file-detection-works)
+    - [Using environment variables](#using-environment-variables)
+    - [Specifying a Custom Compose File, or Multiple Files](#specifying-a-custom-compose-file-or-multiple-files)
+  - [How Compose Files Are Processed](#how-compose-files-are-processed)
+    - [Compose-Spec to Swarm Reconciliation](#compose-spec-to-swarm-reconciliation)
+    - [Variable interpolation](#variable-interpolation)
+  - [Configuring Secrets and Configs](#configuring-secrets-and-configs)
+    - [Loading Environment Variables or inline Content](#loading-environment-variables-or-inline-content)
+    - [Smart Variable Resolution](#smart-variable-resolution)
+    - [Providing GitHub Secrets and Variables](#providing-github-secrets-and-variables)
+    - [Automatic Rotation](#automatic-rotation)
+    - [Configuring the Variable Name](#configuring-the-variable-name)
+    - [Disabling Automatic Variable Management](#disabling-automatic-variable-management)
+    - [Data Transformation](#data-transformation)
+  - [How the stack is deployed](#how-the-stack-is-deployed)
+  - [Post-Deployment Monitoring](#post-deployment-monitoring)
+    - [Monitoring Timeout & Interval](#monitoring-timeout--interval)
+  - [Health Check Validation](#health-check-validation)
+    - [Health Check Details in Failure Reports](#health-check-details-in-failure-reports)
+- [🔨 Contributing](#-contributing)
+
 ## ✨ Features
 
 - **Easy Setup:** The action uses
@@ -57,14 +88,15 @@ on:
 
 jobs:
   deploy:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-          uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
       - name: Deploy to Docker Swarm
-          uses: matchory/deployment@v1
-          environment:
-            DOCKER_HOST: tcp://my-swarm-host:2375
+        uses: matchory/docker-swarm-deployment-action@v1
+        env:
+          DOCKER_HOST: tcp://my-swarm-host:2375
 ```
 
 You could also leverage a Docker context to connect to your Swarm cluster. This is the recommended way to connect to a
@@ -79,6 +111,7 @@ on:
 
 jobs:
   deploy:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -91,7 +124,7 @@ jobs:
           ssh_key: ${{ secrets.SSH_KEY }}
 
       - name: Deploy to Docker Swarm
-        uses: matchory/deployment@v1
+        uses: matchory/docker-swarm-deployment-action@v1
         env:
           DOCKER_CONTEXT: swarm
 ```
@@ -107,13 +140,14 @@ To configure the action, you can use the following inputs:
 | `stack-name`            | _Repository name_                     | The name of the stack to deploy. If not specified, the repository name (without the "user/" part) will be used.                   |
 | `version`               | _Tag Name&thinsp;/&thinsp;Commit SHA_ | The version of the stack to deploy. If not specified, the action will use the tag name or commit SHA of the build.                |
 | `compose-file`          | _—_                                   | The path to the compose file. If not specified, the action will [automatically search for it](#how-compose-file-detection-works). |
-| `env-var-prefix`        | `DEPLOYMENT_`                         | Prefix to resolve variables intended for [auto-configuration of variables](#smart-variable-resolution).                           |
+| `env-var-prefix`        | `DEPLOYMENT`                          | Prefix to resolve variables intended for [auto-configuration of variables](#smart-variable-resolution). A trailing `_` is stripped; the prefix is joined to the variable name with `_`. |
 | `manage-variables`      | `true`                                | Whether to automatically [manage configs and secrets](#configuring-secrets-and-configs).                                          |
-| `strict-variables`      | `false`                               | Whether to throw an error if a variable specified in the compose spec is not defined.                                             |
+| `strict-variables`      | `true`                                | Whether to throw an error if a variable specified in the compose spec is not defined.                                             |
 | `strict-compatibility`  | `false`                               | Whether to fail on Swarm-incompatible features. See [reconciliation](#compose-spec-to-swarm-reconciliation).                      |
+| `key-interpolation`     | `false`                               | Whether to also interpolate variables in Compose Spec _keys_, not just values. See [variable interpolation](#variable-interpolation). |
 | `variables`             | _—_                                   | Variables as KEY=value pairs, newline-separated, or JSON object (e.g., `${{ toJSON(vars) }}`). Applies to environment.            |
 | `secrets`               | _—_                                   | Secrets as KEY=value pairs, newline-separated, or JSON object (e.g., `${{ toJSON(secrets) }}`). Higher priority than variables.   |
-| `exclude-variables`     | _—_                                   | List of variable names to exclude from deployment, separated by newlines. Applies to all variable sources.                        |
+| `exclude-variables`     | _—_                                   | List of variable names to exclude from deployment, separated by newlines. Applies to every source except `extra-variables`.       |
 | `extra-variables`       | _—_                                   | Additional variables as KEY=value pairs, separated by newlines. Highest priority, overrides all other sources.                    |
 | `monitor`               | `false`                               | Whether to [monitor the stack](#post-deployment-monitoring) after deployment.                                                     |
 | `monitor-timeout`       | `300`                                 | The maximum time in seconds to wait for the stack to stabilize.                                                                   |
@@ -134,7 +168,7 @@ To configure the action, you can use the following inputs:
 
 ### How Compose File Detection Works
 
-If the `compose-file` input is not specified, the action automatically searches for your Compose File (s) in the
+If the `compose-file` input is not specified, the action automatically searches for your Compose File(s) in the
 following common locations and names, in descending order:
 
 1. `compose.production.yaml`
@@ -166,7 +200,8 @@ while maintaining full backward compatibility.
 #### Using environment variables
 
 The action also respects the `COMPOSE_FILE` environment variable if set, and multiple files specified there or via the
-`compose-file` input can be separated by the `COMPOSE_FILE_SEPARATOR` environment variable (defaults to `:`).
+`compose-file` input can be separated by the `COMPOSE_PATH_SEPARATOR` environment variable (defaults to `:`). If the
+value contains newlines and `COMPOSE_PATH_SEPARATOR` is not set, newlines are used as the separator instead.
 
 #### Specifying a Custom Compose File, or Multiple Files
 
@@ -175,7 +210,7 @@ will be merged), use the compose-file input:
 
 ```yaml
 - name: Deploy with Custom Compose File
-  uses: your-github-username/your-repo-name@v1
+  uses: matchory/docker-swarm-deployment-action@v1
   with:
     stack-name: my-application
     compose-file: path/to/your/custom-compose.yaml
@@ -185,7 +220,7 @@ To use multiple files, separate them with newlines:
 
 ```yaml
 - name: Deploy with Multiple Compose Files
-  uses: your-github-username/your-repo-name@v1
+  uses: matchory/docker-swarm-deployment-action@v1
   with:
     stack-name: my-application
     compose-file: |
@@ -194,14 +229,14 @@ To use multiple files, separate them with newlines:
 ```
 
 You can also use a custom delimiter (defaults to `:`) by setting the
-`COMPOSE_FILE_SEPARATOR` environment variable.
+`COMPOSE_PATH_SEPARATOR` environment variable.
 
 ### How Compose Files Are Processed
 
 The action is designed to be flexible and robust when it comes to your Compose files. It doesn't strictly require either
 the old v3 format or the new Compose Specification. Instead, it:
 
-- Reads your specified (or detected) Compose File (s).
+- Reads your specified (or detected) Compose File(s).
 - Applies internal transformations to handle known differences between formats for Swarm compatibility.
 - Uses `docker stack config` to validate the resulting configuration and merge multiple files into a single, canonical
   Compose Specification.
@@ -260,7 +295,7 @@ incorrectly.
 
 #### Variable interpolation
 
-All environment variables inside the Compose Spec (s) will be interpolated automatically according to the
+All environment variables inside the Compose Spec(s) will be interpolated automatically according to the
 [Compose Specification rules](https://docs.docker.com/reference/compose-file/interpolation/), with one optional
 improvement: If you enable the `key-interpolation` input, the action will also replace environment variables in all keys
 in your Compose Spec, not just in values. This is useful for dynamic service names or other keys that depend on
@@ -327,9 +362,9 @@ configs:
     # omitting rest for brevity
 ```
 
-The action will create the files in the same directory as the Compose File and append a unique identifier to the
-filename to avoid conflicts. The files will be removed after the deployment is complete, so you don't have to worry
-about leaving temporary files behind to the next action.
+The action will create the files in the working directory and append a unique identifier to the filename to avoid
+conflicts. The files are removed once the deployment no longer needs them — including when the deployment fails — so no
+plain variable values are left behind for a later job to read.
 
 #### Smart Variable Resolution
 
@@ -348,10 +383,10 @@ configs:
 The action will attempt to resolve the variable content automatically, and populate the `file` property with that. This
 is done by the following rules:
 
-1. If a file with the name of the variable exists in working directory named like the variable key with the suffix
-   ".secret" (e.g. `./app_url.secret`), it will be used as the file source.
+1. If a file named after the variable key with the suffix `.secret` exists in the working directory (e.g.
+   `./app_url.secret`), it will be used as the file source.
 2. If an environment variable with one of the following name patterns exists, it will be used as the environment source:
-   n
+
     - Exact variable key (e.g. `app_url`)
     - Uppercase variable key (e.g. `APP_URL`)
     - Variable key prefixed with the [`envVarPrefix`](#inputs) (e.g.
@@ -376,7 +411,7 @@ list each variable individually:
 
 ```yaml
 - name: Deploy to Docker Swarm
-  uses: matchory/deployment@v1
+  uses: matchory/docker-swarm-deployment-action@v1
   with:
     stack-name: my-application
     # Pass all repository variables as JSON
@@ -400,7 +435,7 @@ variables to include:
 
 ```yaml
 - name: Deploy to Docker Swarm
-  uses: matchory/deployment@v1
+  uses: matchory/docker-swarm-deployment-action@v1
   with:
     stack-name: my-application
     variables: |
@@ -420,7 +455,8 @@ ones):
 3. **`secrets` input** (JSON or key-value)
 4. **`extra-variables` input** (highest priority)
 
-The `exclude-variables` filter is applied after all merging is complete.
+The `exclude-variables` filter is applied after the environment, `variables`, and `secrets` sources have been merged,
+but **before** `extra-variables`. Variables passed via `extra-variables` therefore cannot be excluded.
 
 ##### Setting multi-line variables
 
@@ -445,7 +481,7 @@ You can mix JSON and key-value formats as needed:
 ```yaml
 # Example: Use JSON for bulk config, key-value for specific overrides
 - name: Deploy to Docker Swarm
-  uses: matchory/deployment@v1
+  uses: matchory/docker-swarm-deployment-action@v1
   with:
     variables: ${{ toJSON(vars) }}           # All repository variables
     secrets: ${{ toJSON(secrets) }}          # All repository secrets  
@@ -561,11 +597,12 @@ To deploy the final specification, the action uses the `docker stack deploy`
 command effectively like this:
 
 ```shell
-echo $final_schema | docker stack deploy \
+echo $final_spec | docker stack deploy \
      --resolve-image=always \
      --with-registry-auth \
      --compose-file "-" \
-     --detach \
+     --detach=true \
+     --quiet \
      --prune \
   $stack_name
 ```
@@ -595,10 +632,10 @@ seconds, you can set the following inputs:
 ```yaml
 jobs:
   deploy:
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy to Docker Swarm
-        uses: matchory/deployment@v1
-        uses: matchory/deployment@v1
+        uses: matchory/docker-swarm-deployment-action@v1
         with:
           monitor: true
           monitor-timeout: 600 # 10 minutes
@@ -624,7 +661,7 @@ To suppress these warnings, set `health-check-warnings` to `false`:
 
 ```yaml
 - name: Deploy to Docker Swarm
-  uses: matchory/deployment@v1
+  uses: matchory/docker-swarm-deployment-action@v1
   with:
     health-check-warnings: false
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - [🚀 Getting Started](#-getting-started)
   - [Prerequisites](#prerequisites)
   - [Simple Usage](#simple-usage)
-- [⚙️ Configuration](#️-configuration)
+- [⚙ Configuration](#-configuration)
   - [Inputs](#inputs)
   - [Outputs](#outputs)
 - [📖 Reference](#-reference)
@@ -47,6 +47,9 @@
   - [Health Check Validation](#health-check-validation)
     - [Health Check Details in Failure Reports](#health-check-details-in-failure-reports)
 - [🔨 Contributing](#-contributing)
+  - [Development Setup](#development-setup)
+  - [Before Opening a Pull Request](#before-opening-a-pull-request)
+- [📄 License](#-license)
 
 ## ✨ Features
 
@@ -61,6 +64,9 @@
 - **Reliable Deployments:** Validates your configuration before deploying using
   `docker stack config`.
 - **Optional Post-Deployment Monitoring:** Ensures your services are stable after deployment.
+- **Actionable Failure Diagnostics:** When a service fails, the action reports a categorized cause (image pull failure,
+  crash, OOM kill, failing health check, scheduling problem, and more) along with the task attempt history and container
+  logs — in the log output and the job summary alike, so you don't have to SSH into the cluster to find out what broke.
 - **Fully Tested:** An extensive test suite ensures the action works as expected.
 
 ## 🚀 Getting Started
@@ -129,7 +135,7 @@ jobs:
           DOCKER_CONTEXT: swarm
 ```
 
-## ⚙️ Configuration
+## ⚙ Configuration
 
 ### Inputs
 
@@ -675,3 +681,42 @@ This appears in both the action log output and the GitHub Actions job summary.
 ## 🔨 Contributing
 
 Contributions are welcome! If you have any ideas, suggestions, or bug reports, please open an issue or a pull request.
+
+### Development Setup
+
+The action is written in TypeScript and runs on Node 24. After cloning, install the dependencies:
+
+```shell
+npm install
+```
+
+The following scripts are available:
+
+| Task                       | Command              |
+|:---------------------------|:---------------------|
+| Run the full pipeline      | `npm run all`        |
+| Run the tests              | `npm run test`       |
+| Type-check                 | `npm run typecheck`  |
+| Lint                       | `npm run lint`       |
+| Check formatting           | `npm run format:check` |
+| Fix formatting             | `npm run format:write` |
+| Bundle the action          | `npm run package`    |
+
+Linting and formatting are handled by [Biome](https://biomejs.dev/), and the tests run on
+[Vitest](https://vitest.dev/).
+
+### Before Opening a Pull Request
+
+Two things are easy to miss:
+
+- **The `dist/` directory is committed.** [@vercel/ncc](https://github.com/vercel/ncc) bundles the TypeScript sources
+  into a single file that the Actions runner executes, so `npm run package` has to run after any change under `src/`.
+  A dedicated CI workflow fails the build if `dist/` is out of date.
+- **`npm run all` should pass locally.** It chains formatting, linting, type-checking, tests, the coverage badge, and
+  the bundle — the same steps CI runs.
+
+If you changed dependencies, run `npm install` so `package-lock.json` stays in sync; `npm ci` fails otherwise.
+
+## 📄 License
+
+Released under the [MIT License](./LICENSE).


### PR DESCRIPTION
## Problem

The README had grown to 640 lines with no way to navigate it. While adding a table of contents and verifying the anchor targets, a number of documented claims turned out not to match the code.

## Change

Adds a three-level table of contents (h2–h4), skipping the h5 sub-sections under "Providing GitHub Secrets and Variables" — including them would have roughly doubled its length without helping anyone find anything.

### Claims that did not match the code

| Documented | Actual |
| --- | --- |
| `strict-variables` defaults to `false` | `true`, in both `action.yml` and `parseSettings()` |
| `env-var-prefix` defaults to `DEPLOYMENT_` | `DEPLOYMENT`; a trailing `_` is stripped and the prefix is joined with `_` |
| `key-interpolation` | Referenced in prose, missing from the inputs table entirely |
| `COMPOSE_FILE_SEPARATOR` (two places) | `inferComposeFiles()` reads `COMPOSE_PATH_SEPARATOR`, so the documented variable had no effect |
| `exclude-variables` applies "after all merging is complete", to "all variable sources" | `mergeVariables()` applies it *before* `extra-variables`, which therefore cannot be excluded |
| Generated variable files land next to the Compose file | `transformVariable()` writes them to the working directory |

### Broken examples

Two of the nineteen YAML examples did not parse:

- The first Getting Started example had an over-indented `uses:` and used `environment:` where it meant `env:`.
- The monitoring example carried a duplicated `uses:` key.

Neither declared `runs-on:`. Separately, every example referenced `matchory/deployment@v1` or a leftover `your-github-username/your-repo-name@v1` placeholder rather than `matchory/docker-swarm-deployment-action@v1` — so no example in the README could be copy-pasted into a working workflow.

### Gaps filled

- A Development Setup section and a "Before Opening a Pull Request" note. That `dist/` is committed and needs `npm run package`, and that `npm run all` mirrors CI, were documented only in `CLAUDE.md`, which outside contributors never see.
- A License section. The repository ships an MIT `LICENSE` the README never mentioned.
- The structured failure diagnostics in the feature list — the categorized cause, task attempt history, and container logs went unmentioned.

The `⚙️` in the Configuration heading lost its variation selector (`⚙️` → `⚙`). The selector survived GitHub's slugger into the anchor, leaving an invisible U+FE0F in the link target that was trivial to break by retyping. No anchor in the README contains a non-ASCII character now.

`CLAUDE.md` described the markdown line limit as 80 characters; `.github/linters/.markdown-lint.yml` sets 120.

## Verification

- `markdownlint` against `.github/linters/.markdown-lint.yml` — clean on `README.md` and `CLAUDE.md`
- `github-slugger` — all 43 internal anchors resolve against 39 headings, covering the pre-existing cross-references
- `js-yaml` — 19/19 examples parse (2 failed before this change)

## Notes

- Documentation only; no source changes, so `dist/` is untouched.
- #162 adds an `upload-compose-spec` row to the inputs table and will conflict with the table edits here.
- Out of scope, flagged rather than changed: `LICENSE` reads `Copyright GitHub`, a leftover from the action template. Reassigning a copyright holder is not a docs cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNHRCoVcUEBW7D9RE6M4Q