### PR TITLE
ci: check Biome with the pinned version instead of super-linter's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
         id: npm-ci
         run: npm ci
 
+      # Formatting and linting run here, on the Biome version package.json
+      # pins, rather than in super-linter, which bundles its own. See
+      # linter.yml for why the two must not both check TypeScript.
+      - name: Format
+        id: npm-format-check
+        run: npm run format:check
+
+      - name: Lint
+        id: npm-lint
+        run: npm run lint
+
       - name: Typecheck
         id: npm-typecheck
         run: npm run typecheck

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -45,6 +45,13 @@ jobs:
           FILTER_REGEX_EXCLUDE: (dist|docs/superpowers|\.licenses)/.*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: true
+          # Biome is checked in ci.yml instead, using the version pinned in
+          # package.json. Super-linter bundles its own Biome, which drifts from
+          # that pin: 8.7.0 ships 2.5.0 against our 2.5.5, and the two format
+          # some constructs differently with no output that satisfies both. A
+          # green `npm run all` would then fail CI for no discoverable reason.
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
           VALIDATE_CHECKOV: false
           VALIDATE_JAVASCRIPT_ES: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false


### PR DESCRIPTION
## Problem

Super-linter bundles its own Biome, and it drifts from the version
`package.json` pins: v8.7.0 ships **2.5.0** against our **2.5.5**. The two
format some constructs differently, and there is no output that satisfies both.

Concretely, on #155 this shape was formatted one way by 2.5.5 and the other by
2.5.0:

```ts
it.each(["1e3", "5.9", "10s"])("…", (raw) => { … });
```

2.5.5 breaks the arguments one per line; 2.5.0 hugs the callback. Formatting for
either makes the other fail — I verified there is no fixed point. So
`npm run format:write` produced a tree that the `Lint Codebase` gate rejected,
with a fully green local `npm run all` and nothing in the failure output
pointing at a version difference. That cost a debugging round, and it would
recur for anyone who happens to write a construct where the two disagree.

## Change

`ci.yml` had no formatting or lint step at all — which is *why* super-linter's
bundled Biome was the only gate. Both checks move there, running the pinned
version:

```yaml
- name: Format
  run: npm run format:check

- name: Lint
  run: npm run lint
```

and Biome's TypeScript checks are disabled in super-linter so two different
versions are not judging the same files:

```yaml
VALIDATE_BIOME_FORMAT: false
VALIDATE_BIOME_LINT: false
```

## This strengthens the gate rather than weakening it

The coverage is not dropped — it moves, and lands on the version contributors
actually run. After this, a green `npm run all` means a green CI, which was not
previously true. Everything else super-linter validates (YAML, Markdown, Bash,
GitHub Actions, Gitleaks, …) is untouched.

## Verification

Both workflow files parse, `yaml-lint` passes, and `npm run format:check` and
`npm run lint` are clean. The CI run on this PR should show `Format` and `Lint`
steps under **TypeScript Tests**, and no `BIOME_FORMAT` / `BIOME_LINT` entries
under **Lint Codebase**.