### PR TITLE
chore: release v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matchory/docker-swarm-deployment-action",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matchory/docker-swarm-deployment-action",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@matchory/docker-swarm-deployment-action",
   "description": "A GitHub Action to deploy a Docker Swarm stack.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Moritz Friedrich",
     "email": "moritz@matchory.com",


### PR DESCRIPTION
Release preparation for **v1.3.0**. Bumps `package.json` and `package-lock.json`
from 1.2.0; no source changes.

## What is in this release

| PR | Change |
| -- | ------ |
| #162 | Adds the `upload-compose-spec` input, so the interpolated spec artifact can be turned off. Defaults to `true`, so existing workflows are unaffected. |
| #155 | Fixes a silent spec-corruption bug — a merge tag nested inside a managed secret resolved the entry to `undefined` and the deploy *succeeded*. Also audits the user-facing error and warning messages, and rejects non-whole-number `monitor-interval`/`monitor-timeout` values instead of hanging on `NaN`. |
| #172 | Bumps brace-expansion to 2.1.4, closing GHSA-3jxr-9vmj-r5cp. |
| #173 | CI-only: checks Biome with the pinned version rather than super-linter's bundled one. No user-facing effect. |

Minor rather than patch because #162 adds an input.

## Behavior changes worth noting in the release notes

- `monitor-interval` / `monitor-timeout` now reject values that are not positive
  whole numbers, but **only when `monitor: true`**. Workflows that pass an unused
  `0` with monitoring disabled keep working, so this is not a break for them.
- Several error and warning message texts changed. Anyone string-matching on
  them in log assertions may need to adjust; nothing machine-readable (outputs,
  exit codes) changed.

## Verification

`dist/` and `.licenses/` were already current at this commit, so neither needed
regeneration — `check-dist` and `licensed status` both pass unchanged (157
dependencies, 0 errors). 423/423 tests pass. The bump commit is GPG-signed, per
the `required_signatures` rule on `main`.

## After merge

Pushing the `v1.3.0` tag triggers `release.yml`, which creates the rolling `v1.3`
tag and force-re-points `v1` at this release, then opens a GitHub release with
generated notes. That means it publishes to everyone pinned to `v1` the moment
the tag lands. `v1.2` is left where it is.